### PR TITLE
Switch to a `Pin<&mut Request<'a>>` based API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "object-provider"
-version = "0.1.0"
+version = "0.2.0-pre1"
 authors = ["Nika Layzell <nika@thelayzells.com>"]
 edition = "2018"
 description = "Trait for requesting values by type from a given object"


### PR DESCRIPTION
As discussed in https://github.com/rust-lang/rfcs/pull/2895, this API could be made easier to understand by using `Pin<&mut Request<'a>>` rather than a `Request` type with multiple lifetime parameters. 